### PR TITLE
Fix Keil warning: #61-D

### DIFF
--- a/mcucpp/impl/iopin.h
+++ b/mcucpp/impl/iopin.h
@@ -39,9 +39,9 @@ namespace Mcucpp
 		void TPin<PORT, PIN, CONFIG_PORT>::Set(bool val)
 		{
 			if(val)
-				PORT::template Set<1 << PIN>();
+				PORT::template Set<1u << PIN>();
 			else
-				PORT::template Clear<1 << PIN>();
+				PORT::template Clear<1u << PIN>();
 		}
 
 		template<class PORT, uint8_t PIN, class CONFIG_PORT>
@@ -61,7 +61,7 @@ namespace Mcucpp
 		template<class PORT, uint8_t PIN, class CONFIG_PORT>
 		void TPin<PORT, PIN, CONFIG_PORT>::Toggle()
 		{
-			PORT::Toggle(1 << PIN);
+			PORT::Toggle(1u << PIN);
 		}
 
 		template<class PORT, uint8_t PIN, class CONFIG_PORT>
@@ -85,31 +85,31 @@ namespace Mcucpp
 		template<class PORT, uint8_t PIN, class CONFIG_PORT>
 		void TPin<PORT, PIN, CONFIG_PORT>::SetDriverType(DriverType driverType)
 		{
-			ConfigPort::SetDriverType(1 << PIN, driverType);
+			ConfigPort::SetDriverType(1u << PIN, driverType);
 		}
 		
 		template<class PORT, uint8_t PIN, class CONFIG_PORT>
 		void TPin<PORT, PIN, CONFIG_PORT>::SetPullUp(PullMode pullMode)
 		{
-			ConfigPort::SetPullUp(1 << PIN, pullMode);
+			ConfigPort::SetPullUp(1u << PIN, pullMode);
 		}
 		
 		template<class PORT, uint8_t PIN, class CONFIG_PORT>
 		void TPin<PORT, PIN, CONFIG_PORT>::SetSpeed(Speed speed)
 		{
-			ConfigPort::SetSpeed(1 << PIN, speed);
+			ConfigPort::SetSpeed(1u << PIN, speed);
 		}
 
 		template<class PORT, uint8_t PIN, class CONFIG_PORT>
 		void TPin<PORT, PIN, CONFIG_PORT>::AltFuncNumber(uint8_t funcNumber)
 		{
-			ConfigPort::AltFuncNumber(1 << PIN, funcNumber);
+			ConfigPort::AltFuncNumber(1u << PIN, funcNumber);
 		}
 
 		template<class PORT, uint8_t PIN, class CONFIG_PORT>
 		bool TPin<PORT, PIN, CONFIG_PORT>::IsSet()
 		{
-			return (PORT::PinRead() & (typename PORT::DataT)(1 << PIN)) != 0;
+			return (PORT::PinRead() & (typename PORT::DataT)(1u << PIN)) != 0;
 		}
 
 		template<class PORT, uint8_t PIN, class CONFIG_PORT>
@@ -128,9 +128,9 @@ namespace Mcucpp
 		void InvertedPin<PORT, PIN, CONFIG_PORT>::Set(bool val)
 		{
 			if(val)
-				PORT::template Clear<1 << PIN>();
+				PORT::template Clear<1u << PIN>();
 			else
-				PORT::template Set<1 << PIN>();
+				PORT::template Set<1u << PIN>();
 		}
 
 		template<class PORT, uint8_t PIN, class CONFIG_PORT>

--- a/mcucpp/impl/pinlist.h
+++ b/mcucpp/impl/pinlist.h
@@ -324,7 +324,7 @@ namespace IO
 		template <class Head, class Tail>
 		struct GetInversionMask< Typelist<Head, Tail> >
 		{
-			enum{value = (Head::Pin::Inverted ? (1 << Head::Pin::Number) : 0) | GetInversionMask<Tail>::value};
+			enum{value = (Head::Pin::Inverted ? (1u << Head::Pin::Number) : 0) | GetInversionMask<Tail>::value};
 		};
 ////////////////////////////////////////////////////////////////////////////////
 // class template GetPortMask
@@ -342,7 +342,7 @@ namespace IO
 		template <class Head, class Tail>
 		struct GetPortMask< Typelist<Head, Tail> >
 		{
-			enum{value = (1 << Head::Pin::Number) | GetPortMask<Tail>::value};
+			enum{value = (1u << Head::Pin::Number) | GetPortMask<Tail>::value};
 		};
 
 ////////////////////////////////////////////////////////////////////////////////
@@ -361,7 +361,7 @@ namespace IO
 		template <class Head, class Tail>
 		struct GetValueMask< Typelist<Head, Tail> >
 		{
-			enum{value = (1 << Head::Position) | GetValueMask<Tail>::value};
+			enum{value = (1u << Head::Position) | GetValueMask<Tail>::value};
 		};
 ////////////////////////////////////////////////////////////////////////////////
 // class template GetSerialCount
@@ -498,13 +498,13 @@ namespace IO
 
 				if(Head::Pin::Inverted == false)
 				{
-					if(value & (1 << Head::Position))
-						result |= (1 << Head::Pin::Number);
+					if(value & (1u << Head::Position))
+						result |= (1u << Head::Pin::Number);
 				}
 				else
 				{
-					if(!(value & (1 << Head::Position)))
-						result |= (1 << Head::Pin::Number);
+					if(!(value & (1u << Head::Position)))
+						result |= (1u << Head::Pin::Number);
 				}
 
 				return PinWriteIterator<Tail>::AppendValue(value, result);
@@ -546,13 +546,13 @@ namespace IO
 
 				if(Head::Pin::Inverted)
 				{
-					if(!(portValue & (1 << Head::Pin::Number)))
-						result |= (1 << Head::Position);
+					if(!(portValue & (1u << Head::Pin::Number)))
+						result |= (1u << Head::Position);
 
 				}else
 				{
-					if(portValue & (1 << Head::Pin::Number))
-						result |= (1 << Head::Position);
+					if(portValue & (1u << Head::Pin::Number))
+						result |= (1u << Head::Position);
 				}
 
 
@@ -573,8 +573,8 @@ namespace IO
 		template <class Head, class Tail, class DataType, DataType value>
 		struct PinConstWriteIterator< Typelist<Head, Tail>, DataType, value>
 		{
-			static const DataType PortValue = (value & (1 << Head::Position) ?
-					(1 << Head::Pin::Number) : 0) |
+			static const DataType PortValue = (value & (1u << Head::Position) ?
+					(1u << Head::Pin::Number) : 0) |
 					PinConstWriteIterator<Tail, DataType, value>::PortValue;
 		};
 ////////////////////////////////////////////////////////////////////////////////


### PR DESCRIPTION
Fix Keil warning: #61-D: integer operation result is out of range when
PinList or TPin change the most significant bit of the register.
